### PR TITLE
added options for paste as text and image

### DIFF
--- a/Blazeditor.TinyMCE/BlazeditorOption.cs
+++ b/Blazeditor.TinyMCE/BlazeditorOption.cs
@@ -3,7 +3,15 @@
     public class BlazeditorOption
     {
         public bool InlineMode { get; set; }
-        public string Toolbar { get; set; } = "undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | outdent indent";
+
+        public string Plugins { get; set; } = "paste autolink link wordcount";
+
+        public string Toolbar { get; set; } = "undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | outdent indent | link";
+
         public bool ShowMenuBar { get; set; }
+
+        public bool PasteAsText { get; set; }
+
+        public bool PasteDataImage { get; set; }
     }
 }

--- a/Blazeditor.TinyMCE/Interop.cs
+++ b/Blazeditor.TinyMCE/Interop.cs
@@ -1,12 +1,11 @@
 ﻿using Microsoft.JSInterop;
-using System;
 using System.Threading.Tasks;
 
 namespace Blazeditor.TinyMCE
 {
     public static class Interop
     {
-        internal static ValueTask<object> InitialTinyMCE
+        public static ValueTask<object> InitializeTextEditor
         (
             IJSRuntime jSRuntime,
             DotNetObjectReference<TextEditor> dotNetObjectReference,
@@ -17,7 +16,7 @@ namespace Blazeditor.TinyMCE
         {
             return jSRuntime.InvokeAsync<object>
             (
-                "callbackProxy",
+                "blazeditorCallbackProxy",
                 dotNetObjectReference,
                 "blazeditorInit",
                 idSelector,
@@ -25,16 +24,19 @@ namespace Blazeditor.TinyMCE
                 {
                     inlineMode = blazeditorOption.InlineMode,
                     toolbar = blazeditorOption.Toolbar,
-                    menubar = blazeditorOption.ShowMenuBar
+                    menubar = blazeditorOption.ShowMenuBar,
+                    plugins = blazeditorOption.Plugins,
+                    paste_data_images = blazeditorOption.PasteDataImage,
+                    paste_as_text = blazeditorOption.PasteAsText
                 },
                 onchangeCallback
             );
         }
 
-        internal static ValueTask<string> GetContent(IJSRuntime jSRuntime, string id)
+        public static ValueTask<string> GetContent(IJSRuntime jSRuntime, string id)
             => jSRuntime.InvokeAsync<string>("blazeditorGetContent", id);
 
-        internal static ValueTask<object> SetContent(IJSRuntime jSRuntime, string id, string data)
+        public static ValueTask<object> SetContent(IJSRuntime jSRuntime, string id, string data)
             => jSRuntime.InvokeAsync<object>("blazeditorSetContent", id, data);
     }
 }

--- a/Blazeditor.TinyMCE/TextEditor.razor
+++ b/Blazeditor.TinyMCE/TextEditor.razor
@@ -25,7 +25,7 @@ else
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        await Interop.InitialTinyMCE(JSRuntime, DotNetObjectReference.Create(this), Id, BlazeditorOption, nameof(OnChangeCallback));
+        await Interop.InitializeTextEditor(JSRuntime, DotNetObjectReference.Create(this), Id, BlazeditorOption, nameof(OnChangeCallback));
     }
 
     public async Task<string> GetContent()

--- a/Blazeditor.TinyMCE/wwwroot/blazeditor.js
+++ b/Blazeditor.TinyMCE/wwwroot/blazeditor.js
@@ -1,5 +1,5 @@
 ﻿// Proxy function that serves as middlemen
-window.callbackProxy = function (dotNetInstance, callMethod, id, option, callbackMethod) {
+window.blazeditorCallbackProxy = function (dotNetInstance, callMethod, id, option, callbackMethod) {
     // Execute function that will do the actual job
     window[callMethod](id, option, function (result) {
         // Invoke the C# callback method passing the result as parameter
@@ -25,23 +25,25 @@ window.blazeditorInit = function (id, option, callback) {
         });
     }
 
+    var config = {
+        selector: 'textarea#' + id,
+        inline: false,
+        plugins: option.plugins,
+        toolbar: option.toolbar,
+        setup: setup,
+        menubar: option.menubar,
+        default_link_target: '_blank',
+        paste_data_images: option.paste_data_images,
+        paste_as_text: option.paste_as_text,
+        smart_paste: false,
+    };
 
     if (option.inlineMode) {
-        tinymce.init({
-            selector: '#' + id,
-            inline: true,
-            toolbar: option.toolbar,
-            setup: setup,
-            menubar: option.menubar
-        });
-    } else {
-        tinymce.init({
-            selector: 'textarea#' + id,
-            toolbar: option.toolbar,
-            setup: setup,
-            menubar: option.menubar
-        });
-    }
+        config.selector = '#' + id;
+        config.inline = true;        
+    } 
+
+    tinymce.init(config);
 }
 
 window.blazeditorSetContent = function (id, data) {

--- a/Blazeditor.sln
+++ b/Blazeditor.sln
@@ -5,11 +5,11 @@ VisualStudioVersion = 16.0.30413.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A95DCD49-1878-4225-BA3A-C51C31DB2F37}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blazeditor.TinyMCE", "Blazeditor.TinyMCE\Blazeditor.TinyMCE.csproj", "{F2E20D4B-7F5E-47E9-8171-DB1EFD5A2317}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Blazeditor.TinyMCE", "Blazeditor.TinyMCE\Blazeditor.TinyMCE.csproj", "{F2E20D4B-7F5E-47E9-8171-DB1EFD5A2317}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{FDF1438C-5376-42D3-8418-D70CF1AD0FB7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServerSideDemo", "samples\Blazeditor.TinyMCE.Demo\ServerSideDemo.csproj", "{16F4AAF3-FADA-4DF6-B5C7-BB82D3B82FBC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServerSideDemo", "samples\Blazeditor.TinyMCE.Demo\ServerSideDemo.csproj", "{16F4AAF3-FADA-4DF6-B5C7-BB82D3B82FBC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/samples/Blazeditor.TinyMCE.Demo/Pages/Index.razor
+++ b/samples/Blazeditor.TinyMCE.Demo/Pages/Index.razor
@@ -52,14 +52,16 @@
 
     private BlazeditorOption textEditorOption = new BlazeditorOption
     {
-        Toolbar = "undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | outdent indent",
-        ShowMenuBar = true
+        Toolbar = "undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | outdent indent | link",
+        ShowMenuBar = true,
+        PasteAsText = true,
+        PasteDataImage = true
     };
 
     private BlazeditorOption inlineOption = new BlazeditorOption
     {
         InlineMode = true,
-        Toolbar = "bold italic | alignleft aligncenter alignright alignjustify"
+        Toolbar = "bold italic | alignleft aligncenter alignright alignjustify | link"
     };
 
     public async Task GetContent()


### PR DESCRIPTION
- Paste as text without styling from source. 
- Paste an image to editor
- Refactoring `blazeditor.js` 